### PR TITLE
github action workflow for synchronizing central parent repo whenever changes are made

### DIFF
--- a/.github/workflows/notify_parent.yml
+++ b/.github/workflows/notify_parent.yml
@@ -1,0 +1,29 @@
+name: 'Submodule Notify Parent'
+
+on:
+  push:
+    branches:
+      - main    
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  notify:
+    name: 'Submodule Notify Parent'
+    runs-on: ubuntu-latest
+
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Github REST API Call
+      env:
+        CI_TOKEN: ${{ secrets.CI_TOKEN }}
+        PARENT_REPO: 1112zakaria/intelligent-controller-capstone
+        PARENT_BRANCH: main
+        WORKFLOW_ID: submodule_sync.yml
+      run: |
+        curl -fL --retry 3 -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ env.CI_TOKEN }}" https://api.github.com/repos/${{ env.PARENT_REPO }}/actions/workflows/${{ env.WORKFLOW_ID }}/dispatches -d '{"ref":"${{ env.PARENT_BRANCH }}"}'


### PR DESCRIPTION
I need @PatrickLiu0610 to add a CI_TOKEN github secret to the repo under dependabot and actions. Ping Zak to ask how to do this whenever you are ready